### PR TITLE
HAAR-4349: Use postgres for all audit events.

### DIFF
--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -1,0 +1,46 @@
+version: "3.1"
+services:
+
+  audit-db:
+    image: postgres
+    networks:
+      - hmpps
+    container_name: audit-db
+    restart: always
+    ports:
+      - "5432:5432"
+    environment:
+      - POSTGRES_USER=admin
+      - POSTGRES_PASSWORD=admin_password
+      - POSTGRES_DB=audit-db
+
+  localstack:
+    image: localstack/localstack:4
+    networks:
+      - hmpps
+    container_name: localstack
+    ports:
+      - "4566-4597:4566-4597"
+      - 8999:8080
+    environment:
+      - SERVICES=sqs,s3,s3control
+      - DEBUG=${DEBUG- }
+      - DOCKER_HOST=unix:///var/run/docker.sock
+    volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock"
+
+  oauth:
+    image: quay.io/hmpps/hmpps-auth:latest
+    networks:
+      - hmpps
+    container_name: oauth
+    ports:
+      - "8090:8080"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/auth/health"]
+    environment:
+      - SERVER_PORT=8080
+      - SPRING_PROFILES_ACTIVE=dev
+
+networks:
+  hmpps:

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsauditapi/jpa/PrisonerAuditRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsauditapi/jpa/PrisonerAuditRepository.kt
@@ -1,0 +1,44 @@
+package uk.gov.justice.digital.hmpps.hmppsauditapi.jpa
+
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.CrudRepository
+import org.springframework.data.repository.PagingAndSortingRepository
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.hmppsauditapi.jpa.model.PrisonerAuditEvent
+import java.time.Instant
+import java.util.UUID
+
+@Repository
+interface PrisonerAuditRepository :
+  PagingAndSortingRepository<PrisonerAuditEvent, UUID>,
+  CrudRepository<PrisonerAuditEvent, UUID> {
+
+  @Query(
+    """
+    select
+        ae from PrisonerAuditEvent ae
+    where
+        ((cast(:startDate as string) is null or ae.when >=:startDate )
+           and (cast(:endDate as string) is null or ae.when <=:endDate))
+     and (cast(:service as string) is null or ae.service =:service)
+     and (cast(:what as string) is null or ae.what =:what)
+     and (cast(:subjectId as string) is null or ae.subjectId =:subjectId)
+     and (cast(:subjectType as string) is null or ae.subjectType =:subjectType)
+     and (cast(:correlationId as string) is null or ae.correlationId =:correlationId)
+     and (cast(:who as string) is null or ae.who =:who)
+    """,
+  )
+  fun findPage(
+    pageable: Pageable,
+    startDate: Instant?,
+    endDate: Instant?,
+    service: String?,
+    subjectId: String?,
+    subjectType: String?,
+    correlationId: String?,
+    what: String?,
+    who: String?,
+  ): Page<PrisonerAuditEvent>
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsauditapi/jpa/StaffAuditRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsauditapi/jpa/StaffAuditRepository.kt
@@ -6,19 +6,19 @@ import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.CrudRepository
 import org.springframework.data.repository.PagingAndSortingRepository
 import org.springframework.stereotype.Repository
-import uk.gov.justice.digital.hmpps.hmppsauditapi.listeners.HMPPSAuditListener.AuditEvent
+import uk.gov.justice.digital.hmpps.hmppsauditapi.jpa.model.StaffAuditEvent
 import java.time.Instant
 import java.util.UUID
 
 @Repository
-interface AuditRepository :
-  PagingAndSortingRepository<AuditEvent, UUID>,
-  CrudRepository<AuditEvent, UUID> {
+interface StaffAuditRepository :
+  PagingAndSortingRepository<StaffAuditEvent, UUID>,
+  CrudRepository<StaffAuditEvent, UUID> {
 
   @Query(
     """
-    select 
-        ae from AuditEvent ae 
+    select
+        ae from StaffAuditEvent ae
     where
         ((cast(:startDate as string) is null or ae.when >=:startDate )
            and (cast(:endDate as string) is null or ae.when <=:endDate))
@@ -40,5 +40,5 @@ interface AuditRepository :
     correlationId: String?,
     what: String?,
     who: String?,
-  ): Page<AuditEvent>
+  ): Page<StaffAuditEvent>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsauditapi/jpa/model/AuditUser.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsauditapi/jpa/model/AuditUser.kt
@@ -14,7 +14,7 @@ import java.util.UUID
 import kotlin.collections.List
 
 @Entity(name = "AuditUser")
-@Table(name = "audit_user")
+@Table(name = "audit_user", schema = "staff")
 @Schema(description = "Stores a unique ID for each user from auth")
 data class AuditUser(
   @Id

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsauditapi/jpa/model/AuthEmailAddress.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsauditapi/jpa/model/AuthEmailAddress.kt
@@ -14,7 +14,7 @@ import org.hibernate.annotations.UpdateTimestamp
 import java.time.LocalDateTime
 
 @Entity(name = "AuthEmailAddress")
-@Table(name = "auth_email_address")
+@Table(name = "auth_email_address", schema = "staff")
 @Schema(
   description = "Stores all email addresses for a given user." +
     "AUDIT_USER_ID is the unique ID given by the audit service to each user." +

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsauditapi/jpa/model/AuthUserId.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsauditapi/jpa/model/AuthUserId.kt
@@ -14,7 +14,7 @@ import org.hibernate.annotations.UpdateTimestamp
 import java.time.LocalDateTime
 
 @Entity(name = "AuthUserId")
-@Table(name = "auth_user_id")
+@Table(name = "auth_user_id", schema = "staff")
 @Schema(
   description = "Stores all user IDs for a given user. " +
     "AUDIT_USER_ID is the unique ID given by the audit service to each user. " +

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsauditapi/jpa/model/AuthUsername.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsauditapi/jpa/model/AuthUsername.kt
@@ -14,7 +14,7 @@ import org.hibernate.annotations.UpdateTimestamp
 import java.time.LocalDateTime
 
 @Entity(name = "AuthUsername")
-@Table(name = "auth_username")
+@Table(name = "auth_username", schema = "staff")
 @Schema(
   description = "Stores all usernames for a given user." +
     "AUDIT_USER_ID is the unique ID given by the audit service to each user." +

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsauditapi/jpa/model/PrisonerAuditEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsauditapi/jpa/model/PrisonerAuditEvent.kt
@@ -1,0 +1,31 @@
+package uk.gov.justice.digital.hmpps.hmppsauditapi.jpa.model
+
+import io.swagger.v3.oas.annotations.Hidden
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.Instant
+import java.util.UUID
+
+@Entity(name = "PrisonerAuditEvent")
+@Table(name = "AuditEvent", schema = "prisoner")
+@Schema(description = "Audit Event Insert Record")
+data class PrisonerAuditEvent(
+  @Id
+  @GeneratedValue
+  @Hidden
+  var id: UUID? = null,
+  val what: String,
+  @Column(name = "occurred")
+  val `when`: Instant = Instant.now(),
+  val operationId: String? = null,
+  val subjectId: String? = null,
+  val subjectType: String = "NOT_APPLICABLE",
+  val correlationId: String? = null,
+  val who: String? = null,
+  val service: String? = null,
+  val details: String? = null,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsauditapi/jpa/model/StaffAuditEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsauditapi/jpa/model/StaffAuditEvent.kt
@@ -1,0 +1,31 @@
+package uk.gov.justice.digital.hmpps.hmppsauditapi.jpa.model
+
+import io.swagger.v3.oas.annotations.Hidden
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.Instant
+import java.util.UUID
+
+@Entity(name = "StaffAuditEvent")
+@Table(name = "AuditEvent", schema = "staff")
+@Schema(description = "Audit Event Insert Record")
+data class StaffAuditEvent(
+  @Id
+  @GeneratedValue
+  @Hidden
+  var id: UUID? = null,
+  val what: String,
+  @Column(name = "occurred")
+  val `when`: Instant = Instant.now(),
+  val operationId: String? = null,
+  val subjectId: String? = null,
+  val subjectType: String = "NOT_APPLICABLE",
+  val correlationId: String? = null,
+  val who: String? = null,
+  val service: String? = null,
+  val details: String? = null,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsauditapi/listeners/HMPPSAuditListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsauditapi/listeners/HMPPSAuditListener.kt
@@ -7,10 +7,8 @@ import io.awspring.cloud.sqs.annotation.SqsListener
 import io.swagger.v3.oas.annotations.Hidden
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.persistence.Column
-import jakarta.persistence.Entity
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.Id
-import jakarta.persistence.Table
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.hmppsauditapi.config.AthenaPropertiesFactory
 import uk.gov.justice.digital.hmpps.hmppsauditapi.listeners.model.AuditEventType
@@ -36,7 +34,7 @@ class HMPPSAuditListener(
     val cleansedAuditEvent = auditEvent.copy(
       details = auditEvent.details?.jsonString(),
     )
-    auditService.saveAuditEvent(cleansedAuditEvent, athenaPropertiesFactory.getProperties(AuditEventType.STAFF))
+    auditService.saveAuditEvent(cleansedAuditEvent, AuditEventType.STAFF, athenaPropertiesFactory.getProperties(AuditEventType.STAFF))
   }
 
   @SqsListener("prisonerauditqueue", factory = "hmppsQueueContainerFactoryProxy")
@@ -48,7 +46,7 @@ class HMPPSAuditListener(
       details = auditEvent.details?.jsonString(),
     )
 
-    auditService.saveAuditEvent(cleansedAuditEvent, athenaPropertiesFactory.getProperties(AuditEventType.PRISONER))
+    auditService.saveAuditEvent(cleansedAuditEvent, AuditEventType.PRISONER, athenaPropertiesFactory.getProperties(AuditEventType.PRISONER))
   }
 
   private fun patchSubjectTypeIfMissing(message: String): String = try {
@@ -69,8 +67,6 @@ class HMPPSAuditListener(
     "{\"details\":\"$this\"}"
   }
 
-  @Entity(name = "AuditEvent")
-  @Table(name = "AuditEvent")
   @Schema(description = "Audit Event Insert Record")
   data class AuditEvent(
     @Id

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsauditapi/resource/AuditResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsauditapi/resource/AuditResource.kt
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.hmppsauditapi.jpa.model.StaffAuditEvent
 import uk.gov.justice.digital.hmpps.hmppsauditapi.listeners.HMPPSAuditListener.AuditEvent
 import uk.gov.justice.digital.hmpps.hmppsauditapi.model.AuditFilterDto
 import uk.gov.justice.digital.hmpps.hmppsauditapi.resource.swagger.StandardApiResponses
@@ -126,17 +127,17 @@ data class AuditDto(
   )
   val details: String?,
 ) {
-  constructor(auditEvent: AuditEvent) : this(
-    auditEvent.id!!,
-    auditEvent.what,
-    auditEvent.`when`,
-    auditEvent.operationId,
-    auditEvent.subjectId,
-    auditEvent.subjectType,
-    auditEvent.correlationId,
-    auditEvent.who,
-    auditEvent.service,
-    auditEvent.details,
+  constructor(staffAuditEvent: StaffAuditEvent) : this(
+    staffAuditEvent.id!!,
+    staffAuditEvent.what,
+    staffAuditEvent.`when`,
+    staffAuditEvent.operationId,
+    staffAuditEvent.subjectId,
+    staffAuditEvent.subjectType,
+    staffAuditEvent.correlationId,
+    staffAuditEvent.who,
+    staffAuditEvent.service,
+    staffAuditEvent.details,
   )
 }
 

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -15,6 +15,8 @@ spring:
     show-sql: true
   flyway:
     locations: classpath:/db/migration/h2,classpath:/db/migration/dev/data,classpath:/db/migration/common
+    schemas: staff,prisoner
+    default-schema: staff
 
 hmpps:
   repository:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,7 +17,9 @@ spring:
 
   flyway:
     enabled: true
-    locations: classpath:/db/migration/postgres,classpath:/db/migration/common
+    locations: classpath:/db/migration/postgres,classpath:/db/migration/common,classpath:/db/migration/prisoner/postgres,classpath:/db/migration/prisoner/common
+    schemas: staff,prisoner
+    default-schema: staff
 
   security:
     oauth2:

--- a/src/main/resources/db/migration/h2/V1_1__create_audit_event_table.sql
+++ b/src/main/resources/db/migration/h2/V1_1__create_audit_event_table.sql
@@ -1,10 +1,30 @@
-create table audit_event
+CREATE SCHEMA IF NOT EXISTS staff;
+CREATE SCHEMA IF NOT EXISTS prisoner;
+
+create table staff.audit_event
 (
     id              uuid primary key,
     operation_id    varchar(80),
+    correlation_id  varchar(80),
     what            varchar(200) not null,
     occurred        timestamp with time zone not null,
     who             varchar(80),
+    subject_id      varchar(80),
+    subject_type    varchar(100),
+    service         varchar(200),
+    details         varchar(1000)
+);
+
+create table prisoner.audit_event
+(
+    id              uuid primary key,
+    operation_id    varchar(80),
+    correlation_id  varchar(80),
+    what            varchar(200) not null,
+    occurred        timestamp with time zone not null,
+    who             varchar(80),
+    subject_id      varchar(80),
+    subject_type    varchar(100),
     service         varchar(200),
     details         varchar(1000)
 );

--- a/src/main/resources/db/migration/h2/V1_2__add_columns_to_event_table.sql
+++ b/src/main/resources/db/migration/h2/V1_2__add_columns_to_event_table.sql
@@ -1,5 +1,0 @@
-ALTER TABLE audit_event
-    ADD COLUMN subject_id varchar(80);
-
-ALTER TABLE audit_event
-    ADD COLUMN subject_type varchar(100);

--- a/src/main/resources/db/migration/h2/V1_3__add_correlation_id_to_event_table.sql
+++ b/src/main/resources/db/migration/h2/V1_3__add_correlation_id_to_event_table.sql
@@ -1,2 +1,0 @@
-ALTER TABLE audit_event
-    ADD COLUMN correlation_id varchar(80);

--- a/src/main/resources/db/migration/h2/V2_0__add_user_tables.sql
+++ b/src/main/resources/db/migration/h2/V2_0__add_user_tables.sql
@@ -1,4 +1,4 @@
-CREATE TABLE audit_user
+CREATE TABLE staff.audit_user
 (
     id                 UUID PRIMARY KEY,
     creation_time      TIMESTAMP,
@@ -6,7 +6,7 @@ CREATE TABLE audit_user
 );
 
 
-CREATE TABLE auth_user_id
+CREATE TABLE staff.auth_user_id
 (
     id                 SERIAL PRIMARY KEY,
     audit_user_id      UUID         NOT NULL,
@@ -17,7 +17,7 @@ CREATE TABLE auth_user_id
     FOREIGN KEY (audit_user_id) REFERENCES audit_user (id)
 );
 
-CREATE TABLE auth_user_uuid
+CREATE TABLE staff.auth_user_uuid
 (
     id                 SERIAL PRIMARY KEY,
     audit_user_id      UUID      NOT NULL,
@@ -28,7 +28,7 @@ CREATE TABLE auth_user_uuid
     FOREIGN KEY (audit_user_id) REFERENCES audit_user (id)
 );
 
-CREATE TABLE auth_email_address
+CREATE TABLE staff.auth_email_address
 (
     id                 SERIAL PRIMARY KEY,
     audit_user_id      UUID         NOT NULL,
@@ -39,7 +39,7 @@ CREATE TABLE auth_email_address
     FOREIGN KEY (audit_user_id) REFERENCES audit_user (id)
 );
 
-CREATE TABLE auth_username
+CREATE TABLE staff.auth_username
 (
     id                 SERIAL PRIMARY KEY,
     audit_user_id      UUID         NOT NULL,

--- a/src/main/resources/db/migration/postgres/V1_1__create_audit_event_table.sql
+++ b/src/main/resources/db/migration/postgres/V1_1__create_audit_event_table.sql
@@ -1,10 +1,30 @@
-create table audit_event
+CREATE SCHEMA IF NOT EXISTS staff;
+CREATE SCHEMA IF NOT EXISTS prisoner;
+
+create table staff.audit_event
 (
     id              uuid primary key,
     operation_id    varchar(80),
+    correlation_id  varchar(80),
     what            varchar(200) not null,
     occurred        timestamp with time zone not null,
     who             varchar(80),
+    subject_id      varchar(80),
+    subject_type    varchar(100),
+    service         varchar(200),
+    details         json
+);
+
+create table prisoner.audit_event
+(
+    id              uuid primary key,
+    operation_id    varchar(80),
+    correlation_id  varchar(80),
+    what            varchar(200) not null,
+    occurred        timestamp with time zone not null,
+    who             varchar(80),
+    subject_id      varchar(80),
+    subject_type    varchar(100),
     service         varchar(200),
     details         json
 );

--- a/src/main/resources/db/migration/postgres/V1_2__add_columns_to_event_table.sql
+++ b/src/main/resources/db/migration/postgres/V1_2__add_columns_to_event_table.sql
@@ -1,5 +1,0 @@
-ALTER TABLE audit_event
-    ADD COLUMN subject_id varchar(80);
-
-ALTER TABLE audit_event
-    ADD COLUMN subject_type varchar(100);

--- a/src/main/resources/db/migration/postgres/V1_3__add_correlation_id_to_event_table.sql
+++ b/src/main/resources/db/migration/postgres/V1_3__add_correlation_id_to_event_table.sql
@@ -1,2 +1,0 @@
-ALTER TABLE audit_event
-    ADD COLUMN correlation_id varchar(80);

--- a/src/main/resources/db/migration/postgres/V2_0__add_user_tables.sql
+++ b/src/main/resources/db/migration/postgres/V2_0__add_user_tables.sql
@@ -1,4 +1,4 @@
-CREATE TABLE audit_user
+CREATE TABLE staff.audit_user
 (
     id                 UUID PRIMARY KEY,
     creation_time      TIMESTAMP,
@@ -6,7 +6,7 @@ CREATE TABLE audit_user
 );
 
 
-CREATE TABLE auth_user_id
+CREATE TABLE staff.auth_user_id
 (
     id                 SERIAL PRIMARY KEY,
     audit_user_id      UUID         NOT NULL,
@@ -17,7 +17,7 @@ CREATE TABLE auth_user_id
     FOREIGN KEY (audit_user_id) REFERENCES audit_user (id)
 );
 
-CREATE TABLE auth_user_uuid
+CREATE TABLE staff.auth_user_uuid
 (
     id                 SERIAL PRIMARY KEY,
     audit_user_id      UUID      NOT NULL,
@@ -28,7 +28,7 @@ CREATE TABLE auth_user_uuid
     FOREIGN KEY (audit_user_id) REFERENCES audit_user (id)
 );
 
-CREATE TABLE auth_email_address
+CREATE TABLE staff.auth_email_address
 (
     id                 SERIAL PRIMARY KEY,
     audit_user_id      UUID         NOT NULL,
@@ -39,7 +39,7 @@ CREATE TABLE auth_email_address
     FOREIGN KEY (audit_user_id) REFERENCES audit_user (id)
 );
 
-CREATE TABLE auth_username
+CREATE TABLE staff.auth_username
 (
     id                 SERIAL PRIMARY KEY,
     audit_user_id      UUID         NOT NULL,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsauditapi/IntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsauditapi/IntegrationTest.kt
@@ -69,6 +69,7 @@ abstract class IntegrationTest {
   protected val awsSqsDlqUrl by lazy { auditQueueConfig.dlqUrl as String }
 
   protected val awsSqsPrisonerAuditDlqClient by lazy { prisonerAuditQueueConfig.sqsDlqClient as SqsAsyncClient }
+  protected val awsSqsPrisonerAuditUrl by lazy { prisonerAuditQueueConfig.queueUrl }
   protected val awsSqsPrisonerAuditDlqUrl by lazy { prisonerAuditQueueConfig.dlqUrl as String }
 
   protected val staffAthenaProperties = AthenaProperties(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsauditapi/integration/endtoend/AuditTestDatabase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsauditapi/integration/endtoend/AuditTestDatabase.kt
@@ -18,8 +18,10 @@ import org.springframework.test.context.TestPropertySource
 import org.springframework.test.web.reactive.server.WebTestClient
 import org.springframework.web.reactive.function.BodyInserters
 import software.amazon.awssdk.services.sqs.model.SendMessageRequest
+import uk.gov.justice.digital.hmpps.hmppsauditapi.jpa.model.StaffAuditEvent
 import uk.gov.justice.digital.hmpps.hmppsauditapi.listeners.HMPPSAuditListener.AuditEvent
 import uk.gov.justice.digital.hmpps.hmppsauditapi.resource.QueueListenerIntegrationTest
+import uk.gov.justice.digital.hmpps.hmppsauditapi.services.toStaffAuditEvent
 import java.time.Instant
 import java.util.UUID
 
@@ -65,7 +67,7 @@ class AuditTestDatabase @Autowired constructor(
       },
       isNull(),
     )
-    verify(auditRepository).save(any<AuditEvent>())
+    verify(staffAuditRepository).save(any<StaffAuditEvent>())
   }
 
   @Test
@@ -78,10 +80,10 @@ class AuditTestDatabase @Autowired constructor(
       .exchange()
       .expectStatus().isAccepted
 
-    await untilCallTo { mockingDetails(auditRepository).invocations.size } matches { it == 1 }
+    await untilCallTo { mockingDetails(staffAuditRepository).invocations.size } matches { it == 1 }
 
     verify(telemetryClient).trackEvent(eq("hmpps-audit"), any(), isNull())
-    verify(auditRepository).save(any<AuditEvent>())
+    verify(staffAuditRepository).save(any<StaffAuditEvent>())
     verifyNoInteractions(auditS3Client)
   }
 
@@ -105,10 +107,10 @@ class AuditTestDatabase @Autowired constructor(
       .exchange()
       .expectStatus().isAccepted
 
-    await untilCallTo { mockingDetails(auditRepository).invocations.size } matches { it == 1 }
+    await untilCallTo { mockingDetails(staffAuditRepository).invocations.size } matches { it == 1 }
 
     verify(telemetryClient).trackEvent(eq("hmpps-audit"), any(), isNull())
-    verify(auditRepository).save(auditEvent)
+    verify(staffAuditRepository).save(auditEvent.toStaffAuditEvent())
     verifyNoInteractions(auditS3Client)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsauditapi/integration/endtoend/AuditTestPrisonerAuditS3Bucket.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsauditapi/integration/endtoend/AuditTestPrisonerAuditS3Bucket.kt
@@ -52,6 +52,6 @@ class AuditTestPrisonerAuditS3Bucket @Autowired constructor(
       },
       eq("hmpps-prisoner-audit-bucket"),
     )
-    verifyNoInteractions(auditRepository)
+    verifyNoInteractions(staffAuditRepository)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsauditapi/integration/endtoend/AuditTestPrisonerDatabase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsauditapi/integration/endtoend/AuditTestPrisonerDatabase.kt
@@ -1,0 +1,65 @@
+package uk.gov.justice.digital.hmpps.hmppsauditapi.integration.endtoend
+
+import org.assertj.core.api.Assertions.assertThat
+import org.awaitility.kotlin.await
+import org.awaitility.kotlin.matches
+import org.awaitility.kotlin.untilCallTo
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.check
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.isNull
+import org.mockito.kotlin.verify
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.test.context.TestPropertySource
+import org.springframework.test.web.reactive.server.WebTestClient
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest
+import uk.gov.justice.digital.hmpps.hmppsauditapi.jpa.model.PrisonerAuditEvent
+import uk.gov.justice.digital.hmpps.hmppsauditapi.listeners.HMPPSAuditListener.AuditEvent
+import uk.gov.justice.digital.hmpps.hmppsauditapi.resource.QueueListenerIntegrationTest
+
+@TestPropertySource(properties = ["hmpps.repository.saveToS3Bucket=false"])
+class AuditTestPrisonerDatabase @Autowired constructor(
+  override var webTestClient: WebTestClient,
+) : QueueListenerIntegrationTest() {
+
+  private val basicAuditEvent = AuditEvent(what = "basicPrisonerAuditEvent", service = "hmpps-Launchpad-ui")
+
+  @Test
+  fun `will consume an audit event message`() {
+    val message = """
+    {
+      "what": "VISITS_VIEWED",
+      "when": "2021-01-25T12:30:00Z",
+      "operationId": "badea6d876c62e2f5264c94c7b50875e",
+      "subjectId": "y1dea6d876c62e2f5264c94c7b50875r",
+      "subjectType": "PERSON",
+      "who": "bobby.beans",
+      "service": "hmpps-Launchpad-ui",
+      "details": "{ \"VISITS\": \"9\"}"
+    }
+    """
+
+    await untilCallTo { getNumberOfMessagesCurrentlyOnQueue() } matches { it == 0 }
+
+    awsSqsClient.sendMessage(
+      SendMessageRequest.builder().queueUrl(awsSqsPrisonerAuditUrl).messageBody(message).build(),
+    )
+
+    await untilCallTo { getNumberOfMessagesCurrentlyOnQueue() } matches { it == 0 }
+
+    verify(telemetryClient).trackEvent(
+      eq("hmpps-prisoner-audit"),
+      check {
+        assertThat(it["what"]).isEqualTo("VISITS_VIEWED")
+        assertThat(it["when"]).isEqualTo("2021-01-25T12:30:00Z")
+        assertThat(it["operationId"]).isEqualTo("badea6d876c62e2f5264c94c7b50875e")
+        assertThat(it["who"]).isEqualTo("bobby.beans")
+        assertThat(it["service"]).isEqualTo("hmpps-Launchpad-ui")
+        assertThat(it.containsKey("details")).isEqualTo(false)
+      },
+      isNull(),
+    )
+    verify(prisonerAuditRepository).save(any<PrisonerAuditEvent>())
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsauditapi/integration/endtoend/AuditTestS3Bucket.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsauditapi/integration/endtoend/AuditTestS3Bucket.kt
@@ -10,7 +10,6 @@ import org.mockito.kotlin.eq
 import org.mockito.kotlin.isNull
 import org.mockito.kotlin.mockingDetails
 import org.mockito.kotlin.verify
-import org.mockito.kotlin.verifyNoInteractions
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.MediaType
 import org.springframework.test.context.ActiveProfiles
@@ -51,6 +50,6 @@ class AuditTestS3Bucket @Autowired constructor(
       eq(staffAthenaProperties.s3BucketName),
     )
 
-    verifyNoInteractions(auditRepository)
+    verify(staffAuditRepository).save(any())
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsauditapi/integration/queues/RetryDlqTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsauditapi/integration/queues/RetryDlqTest.kt
@@ -10,7 +10,7 @@ import org.mockito.kotlin.verify
 import org.springframework.http.MediaType
 import org.springframework.test.context.TestPropertySource
 import software.amazon.awssdk.services.sqs.model.SendMessageRequest
-import uk.gov.justice.digital.hmpps.hmppsauditapi.listeners.HMPPSAuditListener.AuditEvent
+import uk.gov.justice.digital.hmpps.hmppsauditapi.jpa.model.StaffAuditEvent
 import uk.gov.justice.digital.hmpps.hmppsauditapi.resource.QueueListenerIntegrationTest
 
 @TestPropertySource(properties = ["hmpps.repository.saveToS3Bucket=false"])
@@ -85,7 +85,7 @@ class RetryDlqTest : QueueListenerIntegrationTest() {
       await untilCallTo { getNumberOfMessagesCurrentlyOnDlq() } matches { it == 0 }
       await untilCallTo { getNumberOfMessagesCurrentlyOnQueue() } matches { it == 0 }
 
-      verify(auditRepository).save(any<AuditEvent>())
+      verify(staffAuditRepository).save(any<StaffAuditEvent>())
     }
   }
 
@@ -119,7 +119,7 @@ class RetryDlqTest : QueueListenerIntegrationTest() {
       await untilCallTo { getNumberOfMessagesCurrentlyOnDlq() } matches { it == 0 }
       await untilCallTo { getNumberOfMessagesCurrentlyOnQueue() } matches { it == 0 }
 
-      verify(auditRepository).save(any<AuditEvent>())
+      verify(staffAuditRepository).save(any<StaffAuditEvent>())
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsauditapi/jpa/PrisonerAuditRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsauditapi/jpa/PrisonerAuditRepositoryTest.kt
@@ -8,19 +8,19 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
 import org.springframework.data.domain.Pageable
-import uk.gov.justice.digital.hmpps.hmppsauditapi.listeners.HMPPSAuditListener.AuditEvent
+import uk.gov.justice.digital.hmpps.hmppsauditapi.jpa.model.PrisonerAuditEvent
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 
 @DataJpaTest
-class AuditRepositoryTest {
+class PrisonerAuditRepositoryTest {
 
   @Autowired
-  lateinit var auditRepository: AuditRepository
+  lateinit var prisonerAuditRepository: PrisonerAuditRepository
 
   @AfterEach
   fun `remove test audit events`() {
-    auditRepository.deleteAll()
+    prisonerAuditRepository.deleteAll()
   }
 
   @Suppress("ClassName")
@@ -28,14 +28,14 @@ class AuditRepositoryTest {
   inner class saveAuditEvents {
     @Test
     internal fun `can write to repository with basic attributes`() {
-      auditRepository.save(
-        AuditEvent(
+      prisonerAuditRepository.save(
+        PrisonerAuditEvent(
           what = "An Event with basic attributes",
         ),
       )
 
-      assertThat(auditRepository.count()).isEqualTo(1)
-      val auditEvent = auditRepository.findAll().first()
+      assertThat(prisonerAuditRepository.count()).isEqualTo(1)
+      val auditEvent = prisonerAuditRepository.findAll().first()
 
       assertThat(auditEvent.id).isNotNull
       assertThat(auditEvent.what).isEqualTo("An Event with basic attributes")
@@ -56,8 +56,8 @@ class AuditRepositoryTest {
       }
       """
       val now = Instant.now()
-      auditRepository.save(
-        AuditEvent(
+      prisonerAuditRepository.save(
+        PrisonerAuditEvent(
           what = "An Event with all attributes",
           `when` = now,
           operationId = "123456789",
@@ -68,8 +68,8 @@ class AuditRepositoryTest {
           details = details,
         ),
       )
-      assertThat(auditRepository.count()).isEqualTo(1)
-      val auditEvent = auditRepository.findAll().first()
+      assertThat(prisonerAuditRepository.count()).isEqualTo(1)
+      val auditEvent = prisonerAuditRepository.findAll().first()
       assertThat(auditEvent.id).isNotNull
       assertThat(auditEvent.what).isEqualTo("An Event with all attributes")
       assertThat(auditEvent.`when`).isCloseTo(now, within(1, ChronoUnit.MICROS))
@@ -87,8 +87,8 @@ class AuditRepositoryTest {
   inner class filteredPageAuditEvents {
     @Test
     internal fun `filter audit events by date range, service, what and who`() {
-      auditRepository.save(
-        AuditEvent(
+      prisonerAuditRepository.save(
+        PrisonerAuditEvent(
           what = "An Event by John S",
           `when` = Instant.now(),
           operationId = "123456789",
@@ -98,8 +98,8 @@ class AuditRepositoryTest {
           service = "Service-A",
         ),
       )
-      auditRepository.save(
-        AuditEvent(
+      prisonerAuditRepository.save(
+        PrisonerAuditEvent(
           what = "Another Event By Fred S",
           `when` = Instant.now(),
           operationId = "345678",
@@ -109,8 +109,8 @@ class AuditRepositoryTest {
           service = "Service-B",
         ),
       )
-      auditRepository.save(
-        AuditEvent(
+      prisonerAuditRepository.save(
+        PrisonerAuditEvent(
           what = "Event By John J",
           `when` = Instant.now(),
           operationId = "234567",
@@ -121,8 +121,8 @@ class AuditRepositoryTest {
         ),
       )
 
-      assertThat(auditRepository.count()).isEqualTo(3)
-      val auditEvents = auditRepository.findPage(
+      assertThat(prisonerAuditRepository.count()).isEqualTo(3)
+      val auditEvents = prisonerAuditRepository.findPage(
         Pageable.unpaged(),
         Instant.now().minus(1, ChronoUnit.DAYS),
         Instant.now().plus(1, ChronoUnit.DAYS),
@@ -138,8 +138,8 @@ class AuditRepositoryTest {
 
     @Test
     internal fun `filter audit events by service`() {
-      auditRepository.save(
-        AuditEvent(
+      prisonerAuditRepository.save(
+        PrisonerAuditEvent(
           what = "An Event",
           `when` = Instant.now(),
           operationId = "123456789",
@@ -147,8 +147,8 @@ class AuditRepositoryTest {
           who = "John Smith",
         ),
       )
-      auditRepository.save(
-        AuditEvent(
+      prisonerAuditRepository.save(
+        PrisonerAuditEvent(
           what = "Another Event",
           `when` = Instant.now(),
           operationId = "345678",
@@ -156,8 +156,8 @@ class AuditRepositoryTest {
           who = "Fred Smith",
         ),
       )
-      auditRepository.save(
-        AuditEvent(
+      prisonerAuditRepository.save(
+        PrisonerAuditEvent(
           what = "Another Event By John",
           `when` = Instant.now(),
           operationId = "234567",
@@ -166,8 +166,8 @@ class AuditRepositoryTest {
         ),
       )
 
-      assertThat(auditRepository.count()).isEqualTo(3)
-      val auditEvents = auditRepository.findPage(
+      assertThat(prisonerAuditRepository.count()).isEqualTo(3)
+      val auditEvents = prisonerAuditRepository.findPage(
         Pageable.unpaged(),
         null,
         null,
@@ -183,8 +183,8 @@ class AuditRepositoryTest {
 
     @Test
     internal fun `filter audit events by all null parameters`() {
-      auditRepository.save(
-        AuditEvent(
+      prisonerAuditRepository.save(
+        PrisonerAuditEvent(
           what = "An Event",
           `when` = Instant.now(),
           operationId = "123456789",
@@ -192,8 +192,8 @@ class AuditRepositoryTest {
           who = "John Smith",
         ),
       )
-      auditRepository.save(
-        AuditEvent(
+      prisonerAuditRepository.save(
+        PrisonerAuditEvent(
           what = "Another Event",
           `when` = Instant.now(),
           operationId = "345678",
@@ -201,8 +201,8 @@ class AuditRepositoryTest {
           who = "Fred Smith",
         ),
       )
-      auditRepository.save(
-        AuditEvent(
+      prisonerAuditRepository.save(
+        PrisonerAuditEvent(
           what = "Another Event By John",
           `when` = Instant.now(),
           operationId = "234567",
@@ -211,8 +211,8 @@ class AuditRepositoryTest {
         ),
       )
 
-      assertThat(auditRepository.count()).isEqualTo(3)
-      val auditEvents = auditRepository.findPage(
+      assertThat(prisonerAuditRepository.count()).isEqualTo(3)
+      val auditEvents = prisonerAuditRepository.findPage(
         Pageable.unpaged(),
         null,
         null,
@@ -228,8 +228,8 @@ class AuditRepositoryTest {
 
     @Test
     internal fun `filter audit events by Who`() {
-      auditRepository.save(
-        AuditEvent(
+      prisonerAuditRepository.save(
+        PrisonerAuditEvent(
           what = "An Event",
           `when` = Instant.now(),
           operationId = "123456789",
@@ -237,8 +237,8 @@ class AuditRepositoryTest {
           who = "John Smith",
         ),
       )
-      auditRepository.save(
-        AuditEvent(
+      prisonerAuditRepository.save(
+        PrisonerAuditEvent(
           what = "Another Event",
           `when` = Instant.now(),
           operationId = "345678",
@@ -246,8 +246,8 @@ class AuditRepositoryTest {
           who = "Fred Smith",
         ),
       )
-      auditRepository.save(
-        AuditEvent(
+      prisonerAuditRepository.save(
+        PrisonerAuditEvent(
           what = "Another Event By John",
           `when` = Instant.now(),
           operationId = "234567",
@@ -256,8 +256,8 @@ class AuditRepositoryTest {
         ),
       )
 
-      assertThat(auditRepository.count()).isEqualTo(3)
-      val auditEvents = auditRepository.findPage(
+      assertThat(prisonerAuditRepository.count()).isEqualTo(3)
+      val auditEvents = prisonerAuditRepository.findPage(
         Pageable.unpaged(),
         null,
         null,
@@ -273,8 +273,8 @@ class AuditRepositoryTest {
 
     @Test
     internal fun `filter audit events by start date`() {
-      auditRepository.save(
-        AuditEvent(
+      prisonerAuditRepository.save(
+        PrisonerAuditEvent(
           what = "An Event",
           `when` = Instant.now(),
           operationId = "123456789",
@@ -282,8 +282,8 @@ class AuditRepositoryTest {
           who = "John Smith",
         ),
       )
-      auditRepository.save(
-        AuditEvent(
+      prisonerAuditRepository.save(
+        PrisonerAuditEvent(
           what = "Another Event",
           `when` = Instant.now().minus(1, ChronoUnit.DAYS),
           operationId = "345678",
@@ -291,8 +291,8 @@ class AuditRepositoryTest {
           who = "Fred Smith",
         ),
       )
-      auditRepository.save(
-        AuditEvent(
+      prisonerAuditRepository.save(
+        PrisonerAuditEvent(
           what = "Another Event By John",
           `when` = Instant.now().minus(2, ChronoUnit.DAYS),
           operationId = "234567",
@@ -301,9 +301,9 @@ class AuditRepositoryTest {
         ),
       )
 
-      assertThat(auditRepository.count()).isEqualTo(3)
+      assertThat(prisonerAuditRepository.count()).isEqualTo(3)
 
-      val auditEvents = auditRepository.findPage(
+      val auditEvents = prisonerAuditRepository.findPage(
         Pageable.unpaged(),
         Instant.now().minus(3, ChronoUnit.DAYS),
         null,
@@ -319,8 +319,8 @@ class AuditRepositoryTest {
 
     @Test
     internal fun `filter audit events by end date`() {
-      auditRepository.save(
-        AuditEvent(
+      prisonerAuditRepository.save(
+        PrisonerAuditEvent(
           what = "An Event",
           `when` = Instant.now(),
           operationId = "123456789",
@@ -328,8 +328,8 @@ class AuditRepositoryTest {
           who = "John Smith",
         ),
       )
-      auditRepository.save(
-        AuditEvent(
+      prisonerAuditRepository.save(
+        PrisonerAuditEvent(
           what = "Another Event",
           `when` = Instant.now().minus(1, ChronoUnit.DAYS),
           operationId = "345678",
@@ -337,8 +337,8 @@ class AuditRepositoryTest {
           who = "Fred Smith",
         ),
       )
-      auditRepository.save(
-        AuditEvent(
+      prisonerAuditRepository.save(
+        PrisonerAuditEvent(
           what = "Another Event By John",
           `when` = Instant.now().minus(2, ChronoUnit.DAYS),
           operationId = "234567",
@@ -347,8 +347,8 @@ class AuditRepositoryTest {
         ),
       )
 
-      assertThat(auditRepository.count()).isEqualTo(3)
-      val auditEvents = auditRepository.findPage(
+      assertThat(prisonerAuditRepository.count()).isEqualTo(3)
+      val auditEvents = prisonerAuditRepository.findPage(
         Pageable.unpaged(),
         null,
         Instant.now().minus(1, ChronoUnit.DAYS),
@@ -364,8 +364,8 @@ class AuditRepositoryTest {
 
     @Test
     internal fun `filter audit events by date range`() {
-      auditRepository.save(
-        AuditEvent(
+      prisonerAuditRepository.save(
+        PrisonerAuditEvent(
           what = "An Event",
           `when` = Instant.now(),
           operationId = "123456789",
@@ -373,8 +373,8 @@ class AuditRepositoryTest {
           who = "John Smith",
         ),
       )
-      auditRepository.save(
-        AuditEvent(
+      prisonerAuditRepository.save(
+        PrisonerAuditEvent(
           what = "Another Event",
           `when` = Instant.now().minus(1, ChronoUnit.DAYS),
           operationId = "345678",
@@ -382,8 +382,8 @@ class AuditRepositoryTest {
           who = "Fred Smith",
         ),
       )
-      auditRepository.save(
-        AuditEvent(
+      prisonerAuditRepository.save(
+        PrisonerAuditEvent(
           what = "Another Event By John",
           `when` = Instant.now().minus(2, ChronoUnit.DAYS),
           operationId = "234567",
@@ -392,9 +392,9 @@ class AuditRepositoryTest {
         ),
       )
 
-      assertThat(auditRepository.count()).isEqualTo(3)
+      assertThat(prisonerAuditRepository.count()).isEqualTo(3)
 
-      val auditEvents = auditRepository.findPage(
+      val auditEvents = prisonerAuditRepository.findPage(
         Pageable.unpaged(),
         Instant.now().minus(3, ChronoUnit.DAYS),
         Instant.now(),
@@ -410,8 +410,8 @@ class AuditRepositoryTest {
 
     @Test
     internal fun `filter audit events by date range, where start date is greater than end date, no results expected`() {
-      auditRepository.save(
-        AuditEvent(
+      prisonerAuditRepository.save(
+        PrisonerAuditEvent(
           what = "An Event",
           `when` = Instant.now(),
           operationId = "123456789",
@@ -419,8 +419,8 @@ class AuditRepositoryTest {
           who = "John Smith",
         ),
       )
-      auditRepository.save(
-        AuditEvent(
+      prisonerAuditRepository.save(
+        PrisonerAuditEvent(
           what = "Another Event",
           `when` = Instant.now().minus(1, ChronoUnit.DAYS),
           operationId = "345678",
@@ -428,8 +428,8 @@ class AuditRepositoryTest {
           who = "Fred Smith",
         ),
       )
-      auditRepository.save(
-        AuditEvent(
+      prisonerAuditRepository.save(
+        PrisonerAuditEvent(
           what = "Another Event By John",
           `when` = Instant.now().minus(2, ChronoUnit.DAYS),
           operationId = "234567",
@@ -438,9 +438,9 @@ class AuditRepositoryTest {
         ),
       )
 
-      assertThat(auditRepository.count()).isEqualTo(3)
+      assertThat(prisonerAuditRepository.count()).isEqualTo(3)
 
-      val auditEvents = auditRepository.findPage(
+      val auditEvents = prisonerAuditRepository.findPage(
         Pageable.unpaged(),
         Instant.now(),
         Instant.now().minus(3, ChronoUnit.DAYS),
@@ -456,8 +456,8 @@ class AuditRepositoryTest {
 
     @Test
     internal fun `filter audit events by subjectId`() {
-      auditRepository.save(
-        AuditEvent(
+      prisonerAuditRepository.save(
+        PrisonerAuditEvent(
           what = "An Event",
           `when` = Instant.now(),
           operationId = "123456789",
@@ -467,8 +467,8 @@ class AuditRepositoryTest {
           who = "John Smith",
         ),
       )
-      auditRepository.save(
-        AuditEvent(
+      prisonerAuditRepository.save(
+        PrisonerAuditEvent(
           what = "Another Event",
           `when` = Instant.now(),
           operationId = "345678",
@@ -478,8 +478,8 @@ class AuditRepositoryTest {
           who = "Fred Smith",
         ),
       )
-      auditRepository.save(
-        AuditEvent(
+      prisonerAuditRepository.save(
+        PrisonerAuditEvent(
           what = "Another Event By John",
           `when` = Instant.now(),
           operationId = "234567",
@@ -490,8 +490,8 @@ class AuditRepositoryTest {
         ),
       )
 
-      assertThat(auditRepository.count()).isEqualTo(3)
-      val auditEvents = auditRepository.findPage(
+      assertThat(prisonerAuditRepository.count()).isEqualTo(3)
+      val auditEvents = prisonerAuditRepository.findPage(
         Pageable.unpaged(),
         null,
         null,
@@ -508,8 +508,8 @@ class AuditRepositoryTest {
 
     @Test
     internal fun `filter audit events by subjectType`() {
-      auditRepository.save(
-        AuditEvent(
+      prisonerAuditRepository.save(
+        PrisonerAuditEvent(
           what = "An Event",
           `when` = Instant.now(),
           operationId = "123456789",
@@ -519,8 +519,8 @@ class AuditRepositoryTest {
           who = "John Smith",
         ),
       )
-      auditRepository.save(
-        AuditEvent(
+      prisonerAuditRepository.save(
+        PrisonerAuditEvent(
           what = "Another Event",
           `when` = Instant.now(),
           operationId = "345678",
@@ -530,8 +530,8 @@ class AuditRepositoryTest {
           who = "Fred Smith",
         ),
       )
-      auditRepository.save(
-        AuditEvent(
+      prisonerAuditRepository.save(
+        PrisonerAuditEvent(
           what = "Another Event By John",
           `when` = Instant.now(),
           operationId = "234567",
@@ -542,8 +542,8 @@ class AuditRepositoryTest {
         ),
       )
 
-      assertThat(auditRepository.count()).isEqualTo(3)
-      val auditEvents = auditRepository.findPage(
+      assertThat(prisonerAuditRepository.count()).isEqualTo(3)
+      val auditEvents = prisonerAuditRepository.findPage(
         Pageable.unpaged(),
         null,
         null,
@@ -560,8 +560,8 @@ class AuditRepositoryTest {
 
     @Test
     internal fun `filter audit events by correlationId`() {
-      auditRepository.save(
-        AuditEvent(
+      prisonerAuditRepository.save(
+        PrisonerAuditEvent(
           what = "An Event",
           `when` = Instant.now(),
           service = "Service-A",
@@ -569,8 +569,8 @@ class AuditRepositoryTest {
           correlationId = "correlationId1",
         ),
       )
-      auditRepository.save(
-        AuditEvent(
+      prisonerAuditRepository.save(
+        PrisonerAuditEvent(
           what = "Another Event",
           `when` = Instant.now(),
           service = "Service-B",
@@ -578,8 +578,8 @@ class AuditRepositoryTest {
           correlationId = "correlationId2",
         ),
       )
-      auditRepository.save(
-        AuditEvent(
+      prisonerAuditRepository.save(
+        PrisonerAuditEvent(
           what = "Another Event By John",
           `when` = Instant.now(),
           who = "John Smith",
@@ -587,8 +587,8 @@ class AuditRepositoryTest {
         ),
       )
 
-      assertThat(auditRepository.count()).isEqualTo(3)
-      val auditEvents = auditRepository.findPage(
+      assertThat(prisonerAuditRepository.count()).isEqualTo(3)
+      val auditEvents = prisonerAuditRepository.findPage(
         Pageable.unpaged(),
         null,
         null,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsauditapi/jpa/StaffAuditRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsauditapi/jpa/StaffAuditRepositoryTest.kt
@@ -1,0 +1,606 @@
+package uk.gov.justice.digital.hmpps.hmppsauditapi.jpa
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.within
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.data.domain.Pageable
+import uk.gov.justice.digital.hmpps.hmppsauditapi.jpa.model.StaffAuditEvent
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
+@DataJpaTest
+class StaffAuditRepositoryTest {
+
+  @Autowired
+  lateinit var staffAuditRepository: StaffAuditRepository
+
+  @AfterEach
+  fun `remove test audit events`() {
+    staffAuditRepository.deleteAll()
+  }
+
+  @Suppress("ClassName")
+  @Nested
+  inner class saveAuditEvents {
+    @Test
+    internal fun `can write to repository with basic attributes`() {
+      staffAuditRepository.save(
+        StaffAuditEvent(
+          what = "An Event with basic attributes",
+        ),
+      )
+
+      assertThat(staffAuditRepository.count()).isEqualTo(1)
+      val auditEvent = staffAuditRepository.findAll().first()
+
+      assertThat(auditEvent.id).isNotNull
+      assertThat(auditEvent.what).isEqualTo("An Event with basic attributes")
+      assertThat(auditEvent.`when`).isNotNull
+      assertThat(auditEvent.operationId).isNull()
+      assertThat(auditEvent.who).isNull()
+      assertThat(auditEvent.service).isNull()
+      assertThat(auditEvent.subjectId).isNull()
+      assertThat(auditEvent.subjectType).isEqualTo("NOT_APPLICABLE")
+      assertThat(auditEvent.details).isNull()
+    }
+
+    @Test
+    internal fun `can write to repository with all attributes`() {
+      val details = """
+      {
+        "offenderId": "99"
+      }
+      """
+      val now = Instant.now()
+      staffAuditRepository.save(
+        StaffAuditEvent(
+          what = "An Event with all attributes",
+          `when` = now,
+          operationId = "123456789",
+          who = "John Smith",
+          service = "current-service",
+          subjectId = "11111111",
+          subjectType = "PERSON",
+          details = details,
+        ),
+      )
+      assertThat(staffAuditRepository.count()).isEqualTo(1)
+      val auditEvent = staffAuditRepository.findAll().first()
+      assertThat(auditEvent.id).isNotNull
+      assertThat(auditEvent.what).isEqualTo("An Event with all attributes")
+      assertThat(auditEvent.`when`).isCloseTo(now, within(1, ChronoUnit.MICROS))
+      assertThat(auditEvent.operationId).isEqualTo("123456789")
+      assertThat(auditEvent.who).isEqualTo("John Smith")
+      assertThat(auditEvent.service).isEqualTo("current-service")
+      assertThat(auditEvent.subjectId).isEqualTo("11111111")
+      assertThat(auditEvent.subjectType).isEqualTo("PERSON")
+      assertThat(auditEvent.details).isEqualTo(details)
+    }
+  }
+
+  @Suppress("ClassName")
+  @Nested
+  inner class filteredPageAuditEvents {
+    @Test
+    internal fun `filter audit events by date range, service, what and who`() {
+      staffAuditRepository.save(
+        StaffAuditEvent(
+          what = "An Event by John S",
+          `when` = Instant.now(),
+          operationId = "123456789",
+          subjectId = "111",
+          subjectType = "PERSON",
+          who = "John Smith",
+          service = "Service-A",
+        ),
+      )
+      staffAuditRepository.save(
+        StaffAuditEvent(
+          what = "Another Event By Fred S",
+          `when` = Instant.now(),
+          operationId = "345678",
+          subjectId = "222",
+          subjectType = "PERSON",
+          who = "Fred Smith",
+          service = "Service-B",
+        ),
+      )
+      staffAuditRepository.save(
+        StaffAuditEvent(
+          what = "Event By John J",
+          `when` = Instant.now(),
+          operationId = "234567",
+          subjectId = "333",
+          subjectType = "PERSON",
+          who = "John Jones",
+          service = "Service-C",
+        ),
+      )
+
+      assertThat(staffAuditRepository.count()).isEqualTo(3)
+      val auditEvents = staffAuditRepository.findPage(
+        Pageable.unpaged(),
+        Instant.now().minus(1, ChronoUnit.DAYS),
+        Instant.now().plus(1, ChronoUnit.DAYS),
+        service = "Service-B",
+        what = "Another Event By Fred S",
+        who = "Fred Smith",
+        subjectType = null,
+        subjectId = null,
+        correlationId = null,
+      )
+      assertThat(auditEvents.size).isEqualTo(1)
+    }
+
+    @Test
+    internal fun `filter audit events by service`() {
+      staffAuditRepository.save(
+        StaffAuditEvent(
+          what = "An Event",
+          `when` = Instant.now(),
+          operationId = "123456789",
+          service = "Service-A",
+          who = "John Smith",
+        ),
+      )
+      staffAuditRepository.save(
+        StaffAuditEvent(
+          what = "Another Event",
+          `when` = Instant.now(),
+          operationId = "345678",
+          service = "Service-B",
+          who = "Fred Smith",
+        ),
+      )
+      staffAuditRepository.save(
+        StaffAuditEvent(
+          what = "Another Event By John",
+          `when` = Instant.now(),
+          operationId = "234567",
+          service = "Service-C",
+          who = "John Smith",
+        ),
+      )
+
+      assertThat(staffAuditRepository.count()).isEqualTo(3)
+      val auditEvents = staffAuditRepository.findPage(
+        Pageable.unpaged(),
+        null,
+        null,
+        "Service-B",
+        null,
+        null,
+        null,
+        null,
+        null,
+      )
+      assertThat(auditEvents.size).isEqualTo(1)
+    }
+
+    @Test
+    internal fun `filter audit events by all null parameters`() {
+      staffAuditRepository.save(
+        StaffAuditEvent(
+          what = "An Event",
+          `when` = Instant.now(),
+          operationId = "123456789",
+          service = "Service-A",
+          who = "John Smith",
+        ),
+      )
+      staffAuditRepository.save(
+        StaffAuditEvent(
+          what = "Another Event",
+          `when` = Instant.now(),
+          operationId = "345678",
+          service = "Service-B",
+          who = "Fred Smith",
+        ),
+      )
+      staffAuditRepository.save(
+        StaffAuditEvent(
+          what = "Another Event By John",
+          `when` = Instant.now(),
+          operationId = "234567",
+          service = "Service-C",
+          who = "John Smith",
+        ),
+      )
+
+      assertThat(staffAuditRepository.count()).isEqualTo(3)
+      val auditEvents = staffAuditRepository.findPage(
+        Pageable.unpaged(),
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+      )
+      assertThat(auditEvents.size).isEqualTo(3)
+    }
+
+    @Test
+    internal fun `filter audit events by Who`() {
+      staffAuditRepository.save(
+        StaffAuditEvent(
+          what = "An Event",
+          `when` = Instant.now(),
+          operationId = "123456789",
+          service = "Service-A",
+          who = "John Smith",
+        ),
+      )
+      staffAuditRepository.save(
+        StaffAuditEvent(
+          what = "Another Event",
+          `when` = Instant.now(),
+          operationId = "345678",
+          service = "Service-B",
+          who = "Fred Smith",
+        ),
+      )
+      staffAuditRepository.save(
+        StaffAuditEvent(
+          what = "Another Event By John",
+          `when` = Instant.now(),
+          operationId = "234567",
+          service = "Service-C",
+          who = "John Smith",
+        ),
+      )
+
+      assertThat(staffAuditRepository.count()).isEqualTo(3)
+      val auditEvents = staffAuditRepository.findPage(
+        Pageable.unpaged(),
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        "John Smith",
+      )
+      assertThat(auditEvents.size).isEqualTo(2)
+    }
+
+    @Test
+    internal fun `filter audit events by start date`() {
+      staffAuditRepository.save(
+        StaffAuditEvent(
+          what = "An Event",
+          `when` = Instant.now(),
+          operationId = "123456789",
+          service = "Service-A",
+          who = "John Smith",
+        ),
+      )
+      staffAuditRepository.save(
+        StaffAuditEvent(
+          what = "Another Event",
+          `when` = Instant.now().minus(1, ChronoUnit.DAYS),
+          operationId = "345678",
+          service = "Service-B",
+          who = "Fred Smith",
+        ),
+      )
+      staffAuditRepository.save(
+        StaffAuditEvent(
+          what = "Another Event By John",
+          `when` = Instant.now().minus(2, ChronoUnit.DAYS),
+          operationId = "234567",
+          service = "Service-C",
+          who = "John Smith",
+        ),
+      )
+
+      assertThat(staffAuditRepository.count()).isEqualTo(3)
+
+      val auditEvents = staffAuditRepository.findPage(
+        Pageable.unpaged(),
+        Instant.now().minus(3, ChronoUnit.DAYS),
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+      )
+      assertThat(auditEvents.size).isEqualTo(3)
+    }
+
+    @Test
+    internal fun `filter audit events by end date`() {
+      staffAuditRepository.save(
+        StaffAuditEvent(
+          what = "An Event",
+          `when` = Instant.now(),
+          operationId = "123456789",
+          service = "Service-A",
+          who = "John Smith",
+        ),
+      )
+      staffAuditRepository.save(
+        StaffAuditEvent(
+          what = "Another Event",
+          `when` = Instant.now().minus(1, ChronoUnit.DAYS),
+          operationId = "345678",
+          service = "Service-B",
+          who = "Fred Smith",
+        ),
+      )
+      staffAuditRepository.save(
+        StaffAuditEvent(
+          what = "Another Event By John",
+          `when` = Instant.now().minus(2, ChronoUnit.DAYS),
+          operationId = "234567",
+          service = "Service-C",
+          who = "John Smith",
+        ),
+      )
+
+      assertThat(staffAuditRepository.count()).isEqualTo(3)
+      val auditEvents = staffAuditRepository.findPage(
+        Pageable.unpaged(),
+        null,
+        Instant.now().minus(1, ChronoUnit.DAYS),
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+      )
+      assertThat(auditEvents.size).isEqualTo(2)
+    }
+
+    @Test
+    internal fun `filter audit events by date range`() {
+      staffAuditRepository.save(
+        StaffAuditEvent(
+          what = "An Event",
+          `when` = Instant.now(),
+          operationId = "123456789",
+          service = "Service-A",
+          who = "John Smith",
+        ),
+      )
+      staffAuditRepository.save(
+        StaffAuditEvent(
+          what = "Another Event",
+          `when` = Instant.now().minus(1, ChronoUnit.DAYS),
+          operationId = "345678",
+          service = "Service-B",
+          who = "Fred Smith",
+        ),
+      )
+      staffAuditRepository.save(
+        StaffAuditEvent(
+          what = "Another Event By John",
+          `when` = Instant.now().minus(2, ChronoUnit.DAYS),
+          operationId = "234567",
+          service = "Service-C",
+          who = "John Smith",
+        ),
+      )
+
+      assertThat(staffAuditRepository.count()).isEqualTo(3)
+
+      val auditEvents = staffAuditRepository.findPage(
+        Pageable.unpaged(),
+        Instant.now().minus(3, ChronoUnit.DAYS),
+        Instant.now(),
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+      )
+      assertThat(auditEvents.size).isEqualTo(3)
+    }
+
+    @Test
+    internal fun `filter audit events by date range, where start date is greater than end date, no results expected`() {
+      staffAuditRepository.save(
+        StaffAuditEvent(
+          what = "An Event",
+          `when` = Instant.now(),
+          operationId = "123456789",
+          service = "Service-A",
+          who = "John Smith",
+        ),
+      )
+      staffAuditRepository.save(
+        StaffAuditEvent(
+          what = "Another Event",
+          `when` = Instant.now().minus(1, ChronoUnit.DAYS),
+          operationId = "345678",
+          service = "Service-B",
+          who = "Fred Smith",
+        ),
+      )
+      staffAuditRepository.save(
+        StaffAuditEvent(
+          what = "Another Event By John",
+          `when` = Instant.now().minus(2, ChronoUnit.DAYS),
+          operationId = "234567",
+          service = "Service-C",
+          who = "John Smith",
+        ),
+      )
+
+      assertThat(staffAuditRepository.count()).isEqualTo(3)
+
+      val auditEvents = staffAuditRepository.findPage(
+        Pageable.unpaged(),
+        Instant.now(),
+        Instant.now().minus(3, ChronoUnit.DAYS),
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+      )
+      assertThat(auditEvents.size).isEqualTo(0)
+    }
+
+    @Test
+    internal fun `filter audit events by subjectId`() {
+      staffAuditRepository.save(
+        StaffAuditEvent(
+          what = "An Event",
+          `when` = Instant.now(),
+          operationId = "123456789",
+          service = "Service-A",
+          subjectId = "11111",
+          subjectType = "PERSON",
+          who = "John Smith",
+        ),
+      )
+      staffAuditRepository.save(
+        StaffAuditEvent(
+          what = "Another Event",
+          `when` = Instant.now(),
+          operationId = "345678",
+          service = "Service-B",
+          subjectId = "22222",
+          subjectType = "PERSON",
+          who = "Fred Smith",
+        ),
+      )
+      staffAuditRepository.save(
+        StaffAuditEvent(
+          what = "Another Event By John",
+          `when` = Instant.now(),
+          operationId = "234567",
+          service = "Service-C",
+          subjectId = "33333",
+          subjectType = "PERSON",
+          who = "John Smith",
+        ),
+      )
+
+      assertThat(staffAuditRepository.count()).isEqualTo(3)
+      val auditEvents = staffAuditRepository.findPage(
+        Pageable.unpaged(),
+        null,
+        null,
+        null,
+        "11111",
+        null,
+        null,
+        null,
+        null,
+      )
+      assertThat(auditEvents.size).isEqualTo(1)
+      assertThat(auditEvents.first().subjectId).isEqualTo("11111")
+    }
+
+    @Test
+    internal fun `filter audit events by subjectType`() {
+      staffAuditRepository.save(
+        StaffAuditEvent(
+          what = "An Event",
+          `when` = Instant.now(),
+          operationId = "123456789",
+          service = "Service-A",
+          subjectId = "11111",
+          subjectType = "PERSON",
+          who = "John Smith",
+        ),
+      )
+      staffAuditRepository.save(
+        StaffAuditEvent(
+          what = "Another Event",
+          `when` = Instant.now(),
+          operationId = "345678",
+          service = "Service-B",
+          subjectId = "22222",
+          subjectType = "PERSON",
+          who = "Fred Smith",
+        ),
+      )
+      staffAuditRepository.save(
+        StaffAuditEvent(
+          what = "Another Event By John",
+          `when` = Instant.now(),
+          operationId = "234567",
+          service = "Service-C",
+          subjectId = "33333",
+          subjectType = "SYSTEM",
+          who = "John Smith",
+        ),
+      )
+
+      assertThat(staffAuditRepository.count()).isEqualTo(3)
+      val auditEvents = staffAuditRepository.findPage(
+        Pageable.unpaged(),
+        null,
+        null,
+        null,
+        null,
+        "PERSON",
+        null,
+        null,
+        null,
+      )
+      assertThat(auditEvents.size).isEqualTo(2)
+      assertThat(auditEvents.stream().allMatch { ae -> ae.subjectType == "PERSON" }).isTrue()
+    }
+
+    @Test
+    internal fun `filter audit events by correlationId`() {
+      staffAuditRepository.save(
+        StaffAuditEvent(
+          what = "An Event",
+          `when` = Instant.now(),
+          service = "Service-A",
+          who = "John Smith",
+          correlationId = "correlationId1",
+        ),
+      )
+      staffAuditRepository.save(
+        StaffAuditEvent(
+          what = "Another Event",
+          `when` = Instant.now(),
+          service = "Service-B",
+          who = "Fred Smith",
+          correlationId = "correlationId2",
+        ),
+      )
+      staffAuditRepository.save(
+        StaffAuditEvent(
+          what = "Another Event By John",
+          `when` = Instant.now(),
+          who = "John Smith",
+          correlationId = "correlationId3",
+        ),
+      )
+
+      assertThat(staffAuditRepository.count()).isEqualTo(3)
+      val auditEvents = staffAuditRepository.findPage(
+        Pageable.unpaged(),
+        null,
+        null,
+        null,
+        null,
+        null,
+        "correlationId1",
+        null,
+        null,
+      )
+      assertThat(auditEvents.size).isEqualTo(1)
+      assertThat(auditEvents.first().correlationId).isEqualTo("correlationId1")
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsauditapi/listeners/HMPPSAuditListenerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsauditapi/listeners/HMPPSAuditListenerTest.kt
@@ -8,6 +8,7 @@ import org.mockito.kotlin.doNothing
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.hmppsauditapi.listeners.model.AuditEventType
 import uk.gov.justice.digital.hmpps.hmppsauditapi.resource.QueueListenerIntegrationTest
 
 internal class HMPPSAuditListenerTest : QueueListenerIntegrationTest() {
@@ -25,7 +26,7 @@ internal class HMPPSAuditListenerTest : QueueListenerIntegrationTest() {
   """
     listener.onAuditEvent(message)
 
-    doNothing().whenever(auditService).saveAuditEvent(any(), any())
+    doNothing().whenever(auditService).saveAuditEvent(any(), any(), any())
 
     verify(auditService).saveAuditEvent(
       check {
@@ -35,6 +36,7 @@ internal class HMPPSAuditListenerTest : QueueListenerIntegrationTest() {
         assertThat(it.who).isEqualTo("bobby.beans")
         assertThat(it.service).isEqualTo("offender-service")
       },
+      eq(AuditEventType.STAFF),
       eq(staffAthenaProperties),
     )
   }
@@ -51,7 +53,7 @@ internal class HMPPSAuditListenerTest : QueueListenerIntegrationTest() {
     }
   """
 
-    doNothing().whenever(auditService).saveAuditEvent(any(), any())
+    doNothing().whenever(auditService).saveAuditEvent(any(), any(), any())
 
     listener.onAuditEvent(message)
 
@@ -63,6 +65,7 @@ internal class HMPPSAuditListenerTest : QueueListenerIntegrationTest() {
         assertThat(it.who).isEqualTo("alice.jones")
         assertThat(it.service).isEqualTo("auth-service")
       },
+      eq(AuditEventType.STAFF),
       eq(staffAthenaProperties),
     )
   }
@@ -80,7 +83,7 @@ internal class HMPPSAuditListenerTest : QueueListenerIntegrationTest() {
     }
   """
 
-    doNothing().whenever(auditService).saveAuditEvent(any(), any())
+    doNothing().whenever(auditService).saveAuditEvent(any(), any(), any())
 
     listener.onAuditEvent(message)
 
@@ -93,6 +96,7 @@ internal class HMPPSAuditListenerTest : QueueListenerIntegrationTest() {
         assertThat(it.service).isEqualTo("auth-service")
         assertThat(it.subjectType).isEqualTo("NOT_APPLICABLE")
       },
+      eq(AuditEventType.STAFF),
       eq(staffAthenaProperties),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsauditapi/listeners/HMPPSPrisonerAuditListenerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsauditapi/listeners/HMPPSPrisonerAuditListenerTest.kt
@@ -8,6 +8,7 @@ import org.mockito.kotlin.doNothing
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.hmppsauditapi.listeners.model.AuditEventType
 import uk.gov.justice.digital.hmpps.hmppsauditapi.resource.QueueListenerIntegrationTest
 
 internal class HMPPSPrisonerAuditListenerTest : QueueListenerIntegrationTest() {
@@ -25,7 +26,7 @@ internal class HMPPSPrisonerAuditListenerTest : QueueListenerIntegrationTest() {
   """
     listener.onPrisonerAuditEvent(message)
 
-    doNothing().whenever(auditService).saveAuditEvent(any(), any())
+    doNothing().whenever(auditService).saveAuditEvent(any(), any(), any())
 
     verify(auditService).saveAuditEvent(
       check {
@@ -35,6 +36,7 @@ internal class HMPPSPrisonerAuditListenerTest : QueueListenerIntegrationTest() {
         assertThat(it.who).isEqualTo("bobby.beans")
         assertThat(it.service).isEqualTo("offender-service")
       },
+      eq(AuditEventType.PRISONER),
       eq(prisonerAthenaProperties),
     )
   }
@@ -51,7 +53,7 @@ internal class HMPPSPrisonerAuditListenerTest : QueueListenerIntegrationTest() {
     }
   """
 
-    doNothing().whenever(auditService).saveAuditEvent(any(), any())
+    doNothing().whenever(auditService).saveAuditEvent(any(), any(), any())
 
     listener.onPrisonerAuditEvent(message)
 
@@ -63,6 +65,7 @@ internal class HMPPSPrisonerAuditListenerTest : QueueListenerIntegrationTest() {
         assertThat(it.who).isEqualTo("alice.jones")
         assertThat(it.service).isEqualTo("auth-service")
       },
+      eq(AuditEventType.PRISONER),
       eq(prisonerAthenaProperties),
     )
   }
@@ -80,7 +83,7 @@ internal class HMPPSPrisonerAuditListenerTest : QueueListenerIntegrationTest() {
     }
   """
 
-    doNothing().whenever(auditService).saveAuditEvent(any(), any())
+    doNothing().whenever(auditService).saveAuditEvent(any(), any(), any())
 
     listener.onPrisonerAuditEvent(message)
 
@@ -93,6 +96,7 @@ internal class HMPPSPrisonerAuditListenerTest : QueueListenerIntegrationTest() {
         assertThat(it.service).isEqualTo("auth-service")
         assertThat(it.subjectType).isEqualTo("NOT_APPLICABLE")
       },
+      eq(AuditEventType.PRISONER),
       eq(prisonerAthenaProperties),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsauditapi/resource/AuditResourceFilteredPagingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsauditapi/resource/AuditResourceFilteredPagingTest.kt
@@ -8,8 +8,8 @@ import org.junit.jupiter.api.TestInstance
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.MediaType
 import uk.gov.justice.digital.hmpps.hmppsauditapi.IntegrationTest
-import uk.gov.justice.digital.hmpps.hmppsauditapi.jpa.AuditRepository
-import uk.gov.justice.digital.hmpps.hmppsauditapi.listeners.HMPPSAuditListener.AuditEvent
+import uk.gov.justice.digital.hmpps.hmppsauditapi.jpa.StaffAuditRepository
+import uk.gov.justice.digital.hmpps.hmppsauditapi.jpa.model.StaffAuditEvent
 import java.time.Instant
 import java.util.UUID
 
@@ -17,7 +17,7 @@ import java.util.UUID
 class AuditResourceFilteredPagingTest : IntegrationTest() {
 
   @Autowired
-  private lateinit var auditRepository: AuditRepository
+  private lateinit var staffAuditRepository: StaffAuditRepository
 
   val whatRequestBody = JSONObject().put("what", "OFFENDER_DELETED")
   val whoRequestBody = JSONObject().put("who", "bobby.beans")
@@ -30,12 +30,12 @@ class AuditResourceFilteredPagingTest : IntegrationTest() {
     .put("endDateTime", Instant.parse("2021-04-12T17:17:30Z"))
 
   val listOfAudits = listOf(
-    AuditEvent(
+    StaffAuditEvent(
       UUID.fromString("64505f1e-c9ca-4e54-8c62-d946359b667f"),
       "MINIMUM_FIELDS_EVENT",
       Instant.parse("2021-04-04T17:17:30Z"),
     ),
-    AuditEvent(
+    StaffAuditEvent(
       UUID.fromString("5c5ba3d7-0707-42f1-b9ea-949e22dc17ba"),
       "COURT_REGISTER_BUILDING_UPDATE",
       Instant.parse("2021-04-03T10:15:30Z"),
@@ -47,7 +47,7 @@ class AuditResourceFilteredPagingTest : IntegrationTest() {
       "court-register",
       "{\"courtId\":\"AAAMH1\",\"buildingId\":936,\"building\":{\"id\":936,\"courtId\":\"AAAMH1\",\"buildingName\":\"Main Court Name Changed\"}}",
     ),
-    AuditEvent(
+    StaffAuditEvent(
       UUID.fromString("e5b4800c-dc4e-45f8-826c-877b1f3ce8de"),
       "OFFENDER_DELETED",
       Instant.parse("2021-04-01T15:15:30Z"),
@@ -59,7 +59,7 @@ class AuditResourceFilteredPagingTest : IntegrationTest() {
       "offender-service",
       "{\"offenderId\": \"97\"}",
     ),
-    AuditEvent(
+    StaffAuditEvent(
       UUID.fromString("03a1624a-54e7-453e-8c79-816dbe02fd3c"),
       "OFFENDER_DELETED",
       Instant.parse("2020-12-31T08:11:30Z"),
@@ -76,13 +76,13 @@ class AuditResourceFilteredPagingTest : IntegrationTest() {
   @BeforeAll
   fun `insert test audit events`() {
     listOfAudits.forEach {
-      auditRepository.save(it)
+      staffAuditRepository.save(it)
     }
   }
 
   @AfterAll
   fun `remove test audit events`() {
-    auditRepository.deleteAll()
+    staffAuditRepository.deleteAll()
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsauditapi/resource/AuditResourcePagingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsauditapi/resource/AuditResourcePagingTest.kt
@@ -9,8 +9,8 @@ import org.mockito.kotlin.verify
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.MediaType
 import uk.gov.justice.digital.hmpps.hmppsauditapi.IntegrationTest
-import uk.gov.justice.digital.hmpps.hmppsauditapi.jpa.AuditRepository
-import uk.gov.justice.digital.hmpps.hmppsauditapi.listeners.HMPPSAuditListener.AuditEvent
+import uk.gov.justice.digital.hmpps.hmppsauditapi.jpa.StaffAuditRepository
+import uk.gov.justice.digital.hmpps.hmppsauditapi.jpa.model.StaffAuditEvent
 import uk.gov.justice.digital.hmpps.hmppsauditapi.model.AuditFilterDto
 import java.time.Instant
 import java.util.UUID
@@ -19,17 +19,17 @@ import java.util.UUID
 class AuditResourcePagingTest : IntegrationTest() {
 
   @Autowired
-  private lateinit var auditRepository: AuditRepository
+  private lateinit var staffAuditRepository: StaffAuditRepository
 
   val serviceRequestBody = JSONObject().put("service", "offender-service")
 
   val listOfAudits = listOf(
-    AuditEvent(
+    StaffAuditEvent(
       UUID.fromString("64505f1e-c9ca-4e54-8c62-d946359b667f"),
       "MINIMUM_FIELDS_EVENT",
       Instant.parse("2021-04-04T17:17:30Z"),
     ),
-    AuditEvent(
+    StaffAuditEvent(
       UUID.fromString("5c5ba3d7-0707-42f1-b9ea-949e22dc17ba"),
       "COURT_REGISTER_BUILDING_UPDATE",
       Instant.parse("2021-04-03T10:15:30Z"),
@@ -41,7 +41,7 @@ class AuditResourcePagingTest : IntegrationTest() {
       "court-register",
       "{\"courtId\":\"AAAMH1\",\"buildingId\":936,\"building\":{\"id\":936,\"courtId\":\"AAAMH1\",\"buildingName\":\"Main Court Name Changed\"}}",
     ),
-    AuditEvent(
+    StaffAuditEvent(
       UUID.fromString("e5b4800c-dc4e-45f8-826c-877b1f3ce8de"),
       "OFFENDER_DELETED",
       Instant.parse("2021-04-01T15:15:30Z"),
@@ -53,7 +53,7 @@ class AuditResourcePagingTest : IntegrationTest() {
       "offender-service",
       "{\"offenderId\": \"97\"}",
     ),
-    AuditEvent(
+    StaffAuditEvent(
       UUID.fromString("03a1624a-54e7-453e-8c79-816dbe02fd3c"),
       "OFFENDER_DELETED",
       Instant.parse("2020-12-31T08:11:30Z"),
@@ -70,13 +70,13 @@ class AuditResourcePagingTest : IntegrationTest() {
   @BeforeAll
   fun `insert test audit events`() {
     listOfAudits.forEach {
-      auditRepository.save(it)
+      staffAuditRepository.save(it)
     }
   }
 
   @AfterAll
   fun `remove test audit events`() {
-    auditRepository.deleteAll()
+    staffAuditRepository.deleteAll()
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsauditapi/resource/AuditResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsauditapi/resource/AuditResourceTest.kt
@@ -19,7 +19,8 @@ import org.springframework.data.domain.Sort.Direction.DESC
 import org.springframework.http.MediaType
 import org.springframework.web.reactive.function.BodyInserters
 import uk.gov.justice.digital.hmpps.hmppsauditapi.IntegrationTest
-import uk.gov.justice.digital.hmpps.hmppsauditapi.jpa.AuditRepository
+import uk.gov.justice.digital.hmpps.hmppsauditapi.jpa.StaffAuditRepository
+import uk.gov.justice.digital.hmpps.hmppsauditapi.jpa.model.StaffAuditEvent
 import uk.gov.justice.digital.hmpps.hmppsauditapi.listeners.HMPPSAuditListener.AuditEvent
 import java.time.Instant
 import java.util.UUID
@@ -28,7 +29,7 @@ import java.util.UUID
 class AuditResourceTest : IntegrationTest() {
 
   @MockBean
-  private lateinit var auditRepository: AuditRepository
+  private lateinit var staffAuditRepository: StaffAuditRepository
 
   @TestInstance(PER_CLASS)
   @Nested
@@ -80,7 +81,7 @@ class AuditResourceTest : IntegrationTest() {
     @MethodSource("secureEndpointsGet")
     internal fun `satisfies the correct role and scope`(uri: String) {
       whenever(
-        auditRepository.findPage(
+        staffAuditRepository.findPage(
           any(),
           anyOrNull(),
           anyOrNull(),
@@ -386,12 +387,12 @@ class AuditResourceTest : IntegrationTest() {
     @Test
     fun `find all audit entries`() {
       val listOfAudits = listOf(
-        AuditEvent(
+        StaffAuditEvent(
           UUID.fromString("64505f1e-c9ca-4e54-8c62-d946359b667f"),
           "MINIMUM_FIELDS_EVENT",
           Instant.parse("2021-04-04T17:17:30Z"),
         ),
-        AuditEvent(
+        StaffAuditEvent(
           UUID.fromString("5c5ba3d7-0707-42f1-b9ea-949e22dc17ba"),
           "COURT_REGISTER_BUILDING_UPDATE",
           Instant.parse("2021-04-03T10:15:30Z"),
@@ -403,7 +404,7 @@ class AuditResourceTest : IntegrationTest() {
           "court-register",
           "{\"courtId\":\"AAAMH1\",\"buildingId\":936,\"building\":{\"id\":936,\"courtId\":\"AAAMH1\",\"buildingName\":\"Main Court Name Changed\"}}",
         ),
-        AuditEvent(
+        StaffAuditEvent(
           UUID.fromString("e5b4800c-dc4e-45f8-826c-877b1f3ce8de"),
           "OFFENDER_DELETED",
           Instant.parse("2021-04-01T15:15:30Z"),
@@ -415,7 +416,7 @@ class AuditResourceTest : IntegrationTest() {
           "offender-service",
           "{\"offenderId\": \"97\"}",
         ),
-        AuditEvent(
+        StaffAuditEvent(
           UUID.fromString("03a1624a-54e7-453e-8c79-816dbe02fd3c"),
           "OFFENDER_DELETED",
           Instant.parse("2020-12-31T08:11:30Z"),
@@ -428,7 +429,7 @@ class AuditResourceTest : IntegrationTest() {
           "{\"offenderId\": \"98\"}",
         ),
       )
-      whenever(auditRepository.findAll(Sort.by(DESC, "when"))).thenReturn(
+      whenever(staffAuditRepository.findAll(Sort.by(DESC, "when"))).thenReturn(
         listOfAudits,
       )
 
@@ -438,7 +439,7 @@ class AuditResourceTest : IntegrationTest() {
         .expectStatus().isOk
         .expectBody().json("audit_events".loadJson())
 
-      verify(auditRepository).findAll(Sort.by(DESC, "when"))
+      verify(staffAuditRepository).findAll(Sort.by(DESC, "when"))
     }
   }
   private fun String.loadJson(): String = AuditResourceTest::class.java.getResource("$this.json")!!.readText()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsauditapi/resource/QueueListenerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsauditapi/resource/QueueListenerIntegrationTest.kt
@@ -5,7 +5,8 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.mock.mockito.MockBean
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
 import uk.gov.justice.digital.hmpps.hmppsauditapi.IntegrationTest
-import uk.gov.justice.digital.hmpps.hmppsauditapi.jpa.AuditRepository
+import uk.gov.justice.digital.hmpps.hmppsauditapi.jpa.PrisonerAuditRepository
+import uk.gov.justice.digital.hmpps.hmppsauditapi.jpa.StaffAuditRepository
 import uk.gov.justice.digital.hmpps.hmppsauditapi.listeners.HMPPSAuditListener
 import uk.gov.justice.digital.hmpps.hmppsauditapi.services.AuditS3Client
 import uk.gov.justice.hmpps.sqs.HmppsQueue
@@ -17,7 +18,10 @@ abstract class QueueListenerIntegrationTest : IntegrationTest() {
   lateinit var telemetryClient: TelemetryClient
 
   @MockBean
-  lateinit var auditRepository: AuditRepository
+  lateinit var staffAuditRepository: StaffAuditRepository
+
+  @MockBean
+  lateinit var prisonerAuditRepository: PrisonerAuditRepository
 
   @MockBean
   lateinit var auditS3Client: AuditS3Client

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -46,6 +46,8 @@ spring:
     show-sql: true
   flyway:
     locations: classpath:/db/migration/h2,classpath:/db/migration/dev/data,classpath:/db/migration/common
+    schemas: staff,prisoner
+    default-schema: staff
 
 hmpps:
   repository:


### PR DESCRIPTION
Created Staff and Prisoner schema
Audit Event are now transferred to a StaffAuditEvent or PrisonerAuditEvent DAO just before they are saved to the database.