### PR TITLE
HAAR-5486: validate parameters used for Athena queries

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsauditapi/services/AuditAthenaClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsauditapi/services/AuditAthenaClient.kt
@@ -95,11 +95,32 @@ class AuditAthenaClient(
     athenaClient.startQueryExecution(request)
   }
 
-  // Helper to substitute parameters in a query template
+  // Helper to strictly substitute only known parameters in a query template, with validation
   private fun substituteParameters(queryTemplate: String, parameters: Map<String, String>): String {
+    // Only allow these placeholders to be substituted
+    val allowedPlaceholders = setOf(":startDate", ":endDate", ":who", ":subjectId", ":subjectType") +
+      parameters.keys.filter { it.startsWith(":service") }
+
+    // Check for unexpected placeholders
+    val unexpected = parameters.keys - allowedPlaceholders
+    require(unexpected.isEmpty()) { "Unexpected query parameter(s): $unexpected" }
+
+    // Validate parameter values
+    parameters.forEach { (placeholder, value) ->
+      when (placeholder) {
+        ":startDate", ":endDate" -> require(value.matches(Regex("""\d{4}-\d{2}-\d{2}"""))) { "Invalid date format for $placeholder: $value" }
+        ":who", ":subjectId", ":subjectType" -> require(value.matches(Regex("""^[\w@.\- '\u2019]{1,100}""", RegexOption.IGNORE_CASE))) { "Invalid value for $placeholder: $value" }
+        else -> if (placeholder.startsWith(":service")) {
+          require(value.matches(Regex("""^[a-z0-9\-]{1,50}$""", RegexOption.IGNORE_CASE))) { "Invalid service value: $value" }
+        } else {
+          error("Unknown placeholder: $placeholder")
+        }
+      }
+    }
+
     var query = queryTemplate
     parameters.forEach { (placeholder, value) ->
-      // For string values, wrap in single quotes
+      // For string values, wrap in single quotes (Athena does not support prepared statements)
       query = query.replace(placeholder, "'${escapeSql(value)}'")
     }
     return query

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsauditapi/services/AuditAthenaClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsauditapi/services/AuditAthenaClientTest.kt
@@ -390,5 +390,128 @@ class AuditAthenaClientTest {
     }
   }
 
+  @Nested
+  inner class SubstituteParametersValidation {
+    private val queryTemplate = "SELECT * FROM table WHERE user = :who AND subjectId = :subjectId AND subjectType = :subjectType AND service = :serviceName;"
+
+    private fun assertThrowsIllegalArgumentException(block: () -> Unit): IllegalArgumentException {
+      val thrown = try {
+        block()
+        null
+      } catch (ex: Throwable) {
+        ex
+      }
+      var cause: Throwable? = thrown
+      while (cause is java.lang.reflect.InvocationTargetException && cause.cause != null) {
+        cause = cause.cause
+      }
+      if (cause is IllegalArgumentException) {
+        return cause
+      }
+      println("[DEBUG] Unexpected exception type: ${cause?.javaClass?.name}, message: ${cause?.message}")
+      throw AssertionError("Expected IllegalArgumentException but got: " + cause?.javaClass?.name, cause)
+    }
+
+    @Test
+    fun acceptsValidWhoWithApostrophe() {
+      val params = mapOf(
+        ":who" to "O'Reilly",
+        ":subjectId" to "subject123",
+        ":subjectType" to "typeA",
+        ":serviceName" to "service-name",
+      )
+      val result = invokeSubstituteParameters(queryTemplate, params)
+      assertThat(result).contains("'O''Reilly'")
+    }
+
+    @Test
+    fun rejectsWhoWithInvalidCharacters() {
+      val params = mapOf(
+        ":who" to "bad!user",
+        ":subjectId" to "subject123",
+        ":subjectType" to "typeA",
+        ":serviceName" to "service-name",
+      )
+      val exception = assertThrowsIllegalArgumentException {
+        invokeSubstituteParameters(queryTemplate, params)
+      }
+      assertThat(exception.message).contains("Invalid value for :who")
+    }
+
+    @Test
+    fun rejectsSubjectIdExceedingMaxLength() {
+      val params = mapOf(
+        ":who" to "someone",
+        ":subjectId" to "a".repeat(101),
+        ":subjectType" to "typeA",
+        ":serviceName" to "service-name",
+      )
+      val exception = assertThrowsIllegalArgumentException {
+        invokeSubstituteParameters(queryTemplate, params)
+      }
+      assertThat(exception.message).contains("Invalid value for :subjectId")
+    }
+
+    @Test
+    fun rejectsUnexpectedParameter() {
+      val params = mapOf(
+        ":who" to "someone",
+        ":subjectId" to "subject123",
+        ":subjectType" to "typeA",
+        ":serviceName" to "service-name",
+        ":notAllowed" to "bad",
+      )
+      val exception = assertThrowsIllegalArgumentException {
+        invokeSubstituteParameters(queryTemplate, params)
+      }
+      assertThat(exception.message).contains("Unexpected query parameter(s)")
+    }
+
+    @Test
+    fun acceptsValidServiceParameter() {
+      val params = mapOf(
+        ":who" to "someone",
+        ":subjectId" to "subject123",
+        ":subjectType" to "typeA",
+        ":serviceName" to "service-name",
+      )
+      val result = invokeSubstituteParameters(queryTemplate, params)
+      assertThat(result).contains("'service-name'")
+    }
+
+    @Test
+    fun rejectsServiceParameterWithInvalidCharacters() {
+      val params = mapOf(
+        ":who" to "someone",
+        ":subjectId" to "subject123",
+        ":subjectType" to "typeA",
+        ":serviceName" to "invalid!service",
+      )
+      val exception = assertThrowsIllegalArgumentException {
+        invokeSubstituteParameters(queryTemplate, params)
+      }
+      assertThat(exception.message).contains("Invalid service value")
+    }
+
+    @Test
+    fun rejectsInvalidDateFormat() {
+      val params = mapOf(
+        ":startDate" to "2025/01/01",
+        ":endDate" to "2025-01-02",
+      )
+      val template = "SELECT * FROM table WHERE date >= :startDate AND date <= :endDate;"
+      val exception = assertThrowsIllegalArgumentException {
+        invokeSubstituteParameters(template, params)
+      }
+      assertThat(exception.message).contains("Invalid date format for :startDate")
+    }
+
+    private fun invokeSubstituteParameters(template: String, params: Map<String, String>): String {
+      val method = AuditAthenaClient::class.java.getDeclaredMethod("substituteParameters", String::class.java, Map::class.java)
+      method.isAccessible = true
+      return method.invoke(auditAthenaClient, template, params) as String
+    }
+  }
+
   private fun columnInfo(name: String): ColumnInfo = ColumnInfo.builder().name(name).type("string").build()
 }


### PR DESCRIPTION
resolves Veracode issue - CWE-89: Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection'): uk/gov/justice/digital/hmpps/hmppsauditapi/services/AuditAthenaClient.kt:172